### PR TITLE
avoid running make workflow twice

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,7 +1,10 @@
 name: make
 on:
-  pull_request_target:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
   schedule:
     - cron: '0 4 5,25 * *'
 


### PR DESCRIPTION
- remove pull_request_target -> already runs in PRs thanks to push trigger
- don't run on push with tags -> make-release runs on push with tags