### PR TITLE
add option to drop pip and conda dependencies

### DIFF
--- a/jupyterlab_vre/component_containerizer/handlers.py
+++ b/jupyterlab_vre/component_containerizer/handlers.py
@@ -681,6 +681,8 @@ def map_dependencies(dependencies=None, module_name_mapping=None):
                     set_conda_deps.add(module_name)
                 if pip_package:
                     set_pip_deps.add(module_name)
+    set_conda_deps.discard(None)
+    set_pip_deps.discard(None)
     return set_conda_deps, set_pip_deps
 
 


### PR DESCRIPTION
Dependencies can be dropped from environment.yaml by adding

    "mypackage": null

in the "conda" or "pip" sections of the file at MODULE_MAPPING_URL.

This is useful to for packages that cannot be installed with conda, but are included in the NaaVRE flavor.

This feature was added for R in 7acfd2098e7dcba39a470bc3fcb34ec9715c1dfa