### PR TITLE
Revert "Bump @jupyterlab/mainmenu from 3.5.3 to 3.6.7 in /packages/vre-menu"

### DIFF
--- a/packages/vre-menu/package.json
+++ b/packages/vre-menu/package.json
@@ -37,7 +37,7 @@
         "@emotion/styled": "11.10.6",
         "@jupyterlab/application": "3.5.3",
         "@jupyterlab/apputils": "3.5.3",
-        "@jupyterlab/mainmenu": "3.6.7",
+        "@jupyterlab/mainmenu": "3.5.3",
         "@material-ui/core": "4.12.4",
         "@mui/material": "5.15.6"
     },


### PR DESCRIPTION
Reverts QCDIS/NaaVRE#1268